### PR TITLE
C standard my compiler uses didn't include uint64_t or gettimeofday

### DIFF
--- a/diagnostics/string-timing/string-timing.cc
+++ b/diagnostics/string-timing/string-timing.cc
@@ -32,14 +32,15 @@ class skipped_test {};
 
 #define SKIP  throw skipped_test()
 
+#ifndef __STDC_INT64__
+typedef long long    uint64_t;
+#endif
 
 static uint64_t microclock()
 {
-	timeval tv;
-	
-	int got = gettimeofday( &tv, NULL );
-	
-	return uint64_t( tv.tv_sec ) * 1000000 + tv.tv_usec;
+	struct timespec got;
+	clock_gettime(CLOCK_MONOTONIC, &got);
+	return uint64_t( got.tv_sec ) * 1000000 + (got.tv_nsec / 1000);
 }
 
 #ifdef __MACH__


### PR DESCRIPTION
Don't know if this is the expected result, but I was able to compile and run:

 0  default ctor   :     0     0     0
 1  small   ctor   :   100     0     0
 2  normal  ctor   :   100   100     0
 3  small    copy  :   100   100   100
 4  sharable copy  :     0     0     0
 5  static   copy  :  SKIP   100     0
 6  const iterator :   100     0     0
 7  (COW) iterator :   100     0   100
 8  unsharable copy:   100     0   100
 9  unsharable move:   100     0   100
10  small    move  :   100   100     0
11  sharable move  :   100     0     0
12  moved iterator :   100   100     0
