### PR TITLE
Remove __bounded__ function attributes

### DIFF
--- a/lamp/POSIX-headers/arpa/inet.h
+++ b/lamp/POSIX-headers/arpa/inet.h
@@ -70,18 +70,14 @@ in_addr_t	 inet_addr(const char *);
 int		 inet_aton(const char *, struct in_addr *);
 in_addr_t	 inet_lnaof(struct in_addr);
 struct in_addr	 inet_makeaddr(in_addr_t , in_addr_t);
-char *		 inet_neta(in_addr_t, char *, socklen_t)
-			__attribute__((__bounded__(__string__,2,3)));
+char *		 inet_neta(in_addr_t, char *, socklen_t);
 in_addr_t	 inet_netof(struct in_addr);
 in_addr_t	 inet_network(const char *);
-char		*inet_net_ntop(int, const void *, int, char *, socklen_t)
-			__attribute__((__bounded__(__string__,4,5)));
-int		 inet_net_pton(int, const char *, void *, socklen_t)
-			__attribute__((__bounded__(__string__,3,4)));
+char		*inet_net_ntop(int, const void *, int, char *, socklen_t);
+int		 inet_net_pton(int, const char *, void *, socklen_t);
 char		*inet_ntoa(struct in_addr);
 int		 inet_pton(int, const char *, void *);
-const char	*inet_ntop(int, const void *, char *, socklen_t)
-			__attribute__ ((__bounded__(__string__,3,4)));
+const char	*inet_ntop(int, const void *, char *, socklen_t);
 unsigned int	 inet_nsap_addr(const char *, unsigned char *, int);
 char		*inet_nsap_ntoa(int, const unsigned char *, char *);
 __END_DECLS

--- a/lamp/POSIX-headers/sha1.h
+++ b/lamp/POSIX-headers/sha1.h
@@ -24,22 +24,13 @@ typedef struct {
 __BEGIN_DECLS
 void SHA1Init(SHA1_CTX *);
 void SHA1Pad(SHA1_CTX *);
-void SHA1Transform(u_int32_t [5], const u_int8_t [SHA1_BLOCK_LENGTH])
-	__attribute__((__bounded__(__minbytes__,1,5)))
-	__attribute__((__bounded__(__minbytes__,2,SHA1_BLOCK_LENGTH)));
-void SHA1Update(SHA1_CTX *, const u_int8_t *, size_t)
-	__attribute__((__bounded__(__string__,2,3)));
-void SHA1Final(u_int8_t [SHA1_DIGEST_LENGTH], SHA1_CTX *)
-	__attribute__((__bounded__(__minbytes__,1,SHA1_DIGEST_LENGTH)));
-char *SHA1End(SHA1_CTX *, char *)
-	__attribute__((__bounded__(__minbytes__,2,SHA1_DIGEST_STRING_LENGTH)));
-char *SHA1File(const char *, char *)
-	__attribute__((__bounded__(__minbytes__,2,SHA1_DIGEST_STRING_LENGTH)));
-char *SHA1FileChunk(const char *, char *, off_t, off_t)
-	__attribute__((__bounded__(__minbytes__,2,SHA1_DIGEST_STRING_LENGTH)));
-char *SHA1Data(const u_int8_t *, size_t, char *)
-	__attribute__((__bounded__(__string__,1,2)))
-	__attribute__((__bounded__(__minbytes__,3,SHA1_DIGEST_STRING_LENGTH)));
+void SHA1Transform(u_int32_t [5], const u_int8_t [SHA1_BLOCK_LENGTH]);
+void SHA1Update(SHA1_CTX *, const u_int8_t *, size_t);
+void SHA1Final(u_int8_t [SHA1_DIGEST_LENGTH], SHA1_CTX *);
+char *SHA1End(SHA1_CTX *, char *);
+char *SHA1File(const char *, char *);
+char *SHA1FileChunk(const char *, char *, off_t, off_t);
+char *SHA1Data(const u_int8_t *, size_t, char *);
 __END_DECLS
 
 #define HTONDIGEST(x) do {                                              \

--- a/lamp/POSIX-headers/sha2.h
+++ b/lamp/POSIX-headers/sha2.h
@@ -69,54 +69,33 @@ typedef SHA512_CTX SHA384_CTX;
 __BEGIN_DECLS
 void SHA256_Init(SHA256_CTX *);
 void SHA256_Transform(u_int32_t state[8], const u_int8_t [SHA256_BLOCK_LENGTH]);
-void SHA256_Update(SHA256_CTX *, const u_int8_t *, size_t)
-	__attribute__((__bounded__(__string__,2,3)));
+void SHA256_Update(SHA256_CTX *, const u_int8_t *, size_t);
 void SHA256_Pad(SHA256_CTX *);
-void SHA256_Final(u_int8_t [SHA256_DIGEST_LENGTH], SHA256_CTX *)
-	__attribute__((__bounded__(__minbytes__,1,SHA256_DIGEST_LENGTH)));
-char *SHA256_End(SHA256_CTX *, char *)
-	__attribute__((__bounded__(__minbytes__,2,SHA256_DIGEST_STRING_LENGTH)));
-char *SHA256_File(const char *, char *)
-	__attribute__((__bounded__(__minbytes__,2,SHA256_DIGEST_STRING_LENGTH)));
-char *SHA256_FileChunk(const char *, char *, off_t, off_t)
-	__attribute__((__bounded__(__minbytes__,2,SHA256_DIGEST_STRING_LENGTH)));
-char *SHA256_Data(const u_int8_t *, size_t, char *)
-	__attribute__((__bounded__(__string__,1,2)))
-	__attribute__((__bounded__(__minbytes__,3,SHA256_DIGEST_STRING_LENGTH)));
+void SHA256_Final(u_int8_t [SHA256_DIGEST_LENGTH], SHA256_CTX *);
+char *SHA256_End(SHA256_CTX *, char *);
+char *SHA256_File(const char *, char *);
+char *SHA256_FileChunk(const char *, char *, off_t, off_t);
+char *SHA256_Data(const u_int8_t *, size_t, char *);
 
 void SHA384_Init(SHA384_CTX *);
 void SHA384_Transform(u_int64_t state[8], const u_int8_t [SHA384_BLOCK_LENGTH]);
-void SHA384_Update(SHA384_CTX *, const u_int8_t *, size_t)
-	__attribute__((__bounded__(__string__,2,3)));
+void SHA384_Update(SHA384_CTX *, const u_int8_t *, size_t);
 void SHA384_Pad(SHA384_CTX *);
-void SHA384_Final(u_int8_t [SHA384_DIGEST_LENGTH], SHA384_CTX *)
-	__attribute__((__bounded__(__minbytes__,1,SHA384_DIGEST_LENGTH)));
-char *SHA384_End(SHA384_CTX *, char *)
-	__attribute__((__bounded__(__minbytes__,2,SHA384_DIGEST_STRING_LENGTH)));
-char *SHA384_File(const char *, char *)
-	__attribute__((__bounded__(__minbytes__,2,SHA384_DIGEST_STRING_LENGTH)));
-char *SHA384_FileChunk(const char *, char *, off_t, off_t)
-	__attribute__((__bounded__(__minbytes__,2,SHA384_DIGEST_STRING_LENGTH)));
-char *SHA384_Data(const u_int8_t *, size_t, char *)
-	__attribute__((__bounded__(__string__,1,2)))
-	__attribute__((__bounded__(__minbytes__,3,SHA384_DIGEST_STRING_LENGTH)));
+void SHA384_Final(u_int8_t [SHA384_DIGEST_LENGTH], SHA384_CTX *);
+char *SHA384_End(SHA384_CTX *, char *);
+char *SHA384_File(const char *, char *);
+char *SHA384_FileChunk(const char *, char *, off_t, off_t);
+char *SHA384_Data(const u_int8_t *, size_t, char *);
 
 void SHA512_Init(SHA512_CTX *);
 void SHA512_Transform(u_int64_t state[8], const u_int8_t [SHA512_BLOCK_LENGTH]);
-void SHA512_Update(SHA512_CTX *, const u_int8_t *, size_t)
-	__attribute__((__bounded__(__string__,2,3)));
+void SHA512_Update(SHA512_CTX *, const u_int8_t *, size_t);
 void SHA512_Pad(SHA512_CTX *);
-void SHA512_Final(u_int8_t [SHA512_DIGEST_LENGTH], SHA512_CTX *)
-	__attribute__((__bounded__(__minbytes__,1,SHA512_DIGEST_LENGTH)));
-char *SHA512_End(SHA512_CTX *, char *)
-	__attribute__((__bounded__(__minbytes__,2,SHA512_DIGEST_STRING_LENGTH)));
-char *SHA512_File(const char *, char *)
-	__attribute__((__bounded__(__minbytes__,2,SHA512_DIGEST_STRING_LENGTH)));
-char *SHA512_FileChunk(const char *, char *, off_t, off_t)
-	__attribute__((__bounded__(__minbytes__,2,SHA512_DIGEST_STRING_LENGTH)));
-char *SHA512_Data(const u_int8_t *, size_t, char *)
-	__attribute__((__bounded__(__string__,1,2)))
-	__attribute__((__bounded__(__minbytes__,3,SHA512_DIGEST_STRING_LENGTH)));
+void SHA512_Final(u_int8_t [SHA512_DIGEST_LENGTH], SHA512_CTX *);
+char *SHA512_End(SHA512_CTX *, char *);
+char *SHA512_File(const char *, char *);
+char *SHA512_FileChunk(const char *, char *, off_t, off_t);
+char *SHA512_Data(const u_int8_t *, size_t, char *);
 __END_DECLS
 
 #endif /* _SHA2_H */

--- a/lamp/POSIX-headers/stdlib.h
+++ b/lamp/POSIX-headers/stdlib.h
@@ -156,8 +156,7 @@ int putenv(char *);
 long a64l(const char *);
 char* l64a(long);
 
-char* initstate(unsigned int, char *, size_t)
-	__attribute__((__bounded__ (__string__,2,3)));
+char* initstate(unsigned int, char *, size_t);
 long random(void);
 char* setstate(const char *);
 void srandom(unsigned int);
@@ -245,8 +244,7 @@ u_quad_t strtouq(const char *, char **, int);
 
 u_int32_t arc4random(void);
 void arc4random_stir(void);
-void arc4random_addrandom(unsigned char *, int)
-	__attribute__((__bounded__ (__string__,1,2)));
+void arc4random_addrandom(unsigned char *, int);
 #endif /* __BSD_VISIBLE */
 
 __END_DECLS

--- a/lamp/POSIX-headers/string.h
+++ b/lamp/POSIX-headers/string.h
@@ -46,17 +46,13 @@ void* memmem( const void* haystack, size_t haystack_len, const void* needle, siz
 char	*strtok_r(char *, const char *, char **);
 
 #if __BSD_VISIBLE || __XPG_VISIBLE
-void	*memccpy(void *, const void *, int, size_t)
-		__attribute__ ((__bounded__(__buffer__,1,4)));
+void	*memccpy(void *, const void *, int, size_t);
 #endif
 
 #if __BSD_VISIBLE || __XPG_VISIBLE >= 420
 int	 bcmp(const void *, const void *, size_t);
-void	 bcopy(const void *, void *, size_t)
-		__attribute__ ((__bounded__(__buffer__,1,3)))
-		__attribute__ ((__bounded__(__buffer__,2,3)));
-void	 bzero(void *, size_t)
-		__attribute__ ((__bounded__(__buffer__,1,2)));
+void	 bcopy(const void *, void *, size_t);
+void	 bzero(void *, size_t);
 int	 ffs(int);
 char	*index(const char *, int);
 char	*rindex(const char *, int);
@@ -66,16 +62,13 @@ char	*strdup(const char *);
 #endif
 
 #if __BSD_VISIBLE || __XPG_VISIBLE >= 600
-int	 strerror_r(int, char *, size_t)
-	    __attribute__ ((__bounded__(__string__,2,3)));
+int	 strerror_r(int, char *, size_t);
 #endif
 
 #if __BSD_VISIBLE
 char	*strcasestr(const char *, const char *);
-size_t	 strlcat(char *, const char *, size_t)
-		__attribute__ ((__bounded__(__string__,1,3)));
-size_t	 strlcpy(char *, const char *, size_t)
-		__attribute__ ((__bounded__(__string__,1,3)));
+size_t	 strlcat(char *, const char *, size_t);
+size_t	 strlcpy(char *, const char *, size_t);
 void	 strmode(mode_t, char *);
 char	*strsep(char **, const char *);
 const char	*strsignal(int);

--- a/lamp/POSIX-headers/unistd.h
+++ b/lamp/POSIX-headers/unistd.h
@@ -107,9 +107,7 @@ int	 execvp(const char *, char * const *);
 int	 execvpe(const char *, char * const *, char * const *);
 pid_t	 fork(void);
 long	 fpathconf(int, int);
-char	*getcwd(char *, size_t)
-		__attribute__((__bounded__(__string__,1,2)))
-		__attribute__((__bounded__(__minbytes__,1,1024)));
+char	*getcwd(char *, size_t);
 gid_t	 getegid(void);
 uid_t	 geteuid(void);
 gid_t	 getgid(void);
@@ -125,8 +123,7 @@ off_t	 lseek(int, off_t, int);
 long	 pathconf(const char *, int);
 int	 pause(void);
 int	 pipe(int *);
-ssize_t	 read(int, void *, size_t)
-		__attribute__((__bounded__(__buffer__,2,3)));
+ssize_t	 read(int, void *, size_t);
 int	 rmdir(const char *);
 int	 setgid(gid_t);
 int	 setuid(uid_t);
@@ -138,8 +135,7 @@ char	*ttyname(int);
 ssize_t ttyname_k( int, char*, size_t );  // jjuran
 int	 unlink(const char *);
 int updateat( int olddirfd, const char* oldpath, int newdirfd, const char* newpath, unsigned flags );  // jjuran
-ssize_t	 write(int, const void *, size_t)
-		__attribute__((__bounded__(__buffer__,2,3)));
+ssize_t	 write(int, const void *, size_t);
 
 #if __POSIX_VISIBLE || __XPG_VISIBLE >= 300
 pid_t	 setsid(void);
@@ -147,8 +143,7 @@ int	 setpgid(pid_t, pid_t);
 #endif
 
 #if __POSIX_VISIBLE >= 199209 || __XPG_VISIBLE
-size_t	 confstr(int, char *, size_t)
-		__attribute__((__bounded__(__string__,2,3)));
+size_t	 confstr(int, char *, size_t);
 #ifndef _GETOPT_DEFINED_
 #define _GETOPT_DEFINED_
 int	 getopt(int, char * const *, const char *);
@@ -163,9 +158,7 @@ extern	 char *suboptarg;		/* getsubopt(3) external variable */
 #if __POSIX_VISIBLE >= 199506 || __XPG_VISIBLE
 int	 fsync(int);
 int	 ftruncate(int, off_t);
-int	 getlogin_r(char *, size_t)
-		__attribute__((__bounded__(__string__,1,2)))
-		__attribute__((__bounded__(__minbytes__,1,32)));
+int	 getlogin_r(char *, size_t);
 #endif
 
 #if __XPG_VISIBLE || __BSD_VISIBLE
@@ -174,14 +167,12 @@ int	 encrypt(char *, int);
 int	 fchdir(int);
 int	 fchown(int, uid_t, gid_t);
 long	 gethostid(void);
-char	*getwd(char *)
-		__attribute__ ((__bounded__(__minbytes__,1,1024)));
+char	*getwd(char *);
 int	 lchown(const char *, uid_t, gid_t);
 int	 mkstemp(char *);
 char	*mktemp(char *);
 int	 nice(int);
-ssize_t	 readlink(const char *, char *, size_t)
-		__attribute__ ((__bounded__(__string__,2,3)));
+ssize_t	 readlink(const char *, char *, size_t);
 int	 setkey(const char *);
 int	 setpgrp(pid_t pid, pid_t pgrp);	/* obsoleted by setpgid() */
 int	 setregid(gid_t, gid_t);
@@ -202,8 +193,7 @@ pid_t	 getsid(pid_t);
 #if __XPG_VISIBLE >= 500
 ssize_t  pread(int, void *, size_t, off_t);
 ssize_t  pwrite(int, const void *, size_t, off_t);
-int	 ttyname_r(int, char *, size_t)
-	    __attribute__((__bounded__(__string__,2,3)));
+int	 ttyname_r(int, char *, size_t);
 #endif
 
 #if __BSD_VISIBLE ||  __XPG_VISIBLE <= 500
@@ -222,8 +212,7 @@ int     lockf(int, int, off_t);
 
 #if __POSIX_VISIBLE >= 200112 || __XPG_VISIBLE >= 420 || __BSD_VISIBLE
 int	 symlink(const char *, const char *);
-int	 gethostname(char *, size_t)
-		__attribute__ ((__bounded__(__string__,1,2)));
+int	 gethostname(char *, size_t);
 int	 setegid(gid_t);
 int	 seteuid(uid_t);
 #endif
@@ -236,8 +225,7 @@ int	 des_setkey(const char *);
 void	 endusershell(void);
 int	 exect(const char *, char * const *, char * const *);
 char	*fflagstostr(u_int32_t);
-int	 getdomainname(char *, size_t)
-		__attribute__ ((__bounded__(__string__,1,2)));
+int	 getdomainname(char *, size_t);
 int	 getgrouplist(const char *, gid_t, gid_t *, int *);
 mode_t	 getmode(const void *, mode_t);
 int	 getresgid(gid_t *, gid_t *, gid_t *);
@@ -251,8 +239,7 @@ char	*mkdtemp(char *);
 int	 mkstemps(char *, int);
 int	 nfssvc(int, void *);
 void	 psignal(unsigned int, const char *);
-int	 profil(char *, size_t, unsigned long, unsigned int)
-		__attribute__ ((__bounded__(__string__,1,2)));
+int	 profil(char *, size_t, unsigned long, unsigned int);
 int	 quotactl(const char *, int, int, char *);
 int	 rcmd(char **, int, const char *,
 	    const char *, const char *, int *);


### PR DESCRIPTION
Only specific older versions of the GCC compiler (mostly OpenBSD-specific versions) used the __bounded__ function attributes.

Since we're really only compiling the lamp/MacRelix headers with either Codewarrior or Retro68, there really isn't much reason to leave them in the tree.  At best, they're ignored (by Metrowerks), and at worst they cause nasty compile-time errors (any modern GCC like the one in Retro68's toolchain).