### PR TITLE
ams-common: remove "sources" line from A-line.conf

### DIFF
--- a/68k/ams/common/A-line.conf
+++ b/68k/ams/common/A-line.conf
@@ -4,5 +4,3 @@ product lib
 
 use math
 use POSIX-headers
-
-sources common


### PR DESCRIPTION
The sources line causes build.pl to look for the nonexistent 68k/ams/common//common directory.  Tested to still work with A-line under MacRelix after the fix.