### PR TITLE
Pearl: a new cross-platform front end for AMS

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -207,6 +207,9 @@ ams-x11-install: ams-x11-build ams-68k-install ams-common-install
 ams-quartz-build: $(AMS_REPOS) build-tools
 	$(BUILD) graft mbin xv68k fndr-sync minivx freemountd Amethyst Amphitheatre
 
+ams-sdl-build: $(AMS_REPOS) build-tools
+	$(BUILD) graft mbin xv68k fndr-sync minivx freemountd Pearl
+
 RETROMATIC := PATH="$$PWD/$(VAR_BIN):$$PATH" v/bin/retromatic.vx
 RETRO_APPS := ~/Applications/"Advanced Mac Substitute"
 

--- a/apps/sdl/Pearl/A-line.conf
+++ b/apps/sdl/Pearl/A-line.conf
@@ -1,0 +1,14 @@
+product tool
+
+use frontend-common
+use libsdl2
+use libsndtrack
+use log-of-war
+use plus
+use posix-utils
+use rasterlib
+use shared_cursor
+use splode
+use write-a-splode
+
+frameworks Carbon

--- a/apps/sdl/Pearl/Pearl/MainMenu.xib
+++ b/apps/sdl/Pearl/Pearl/MainMenu.xib
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+        <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+            <items>
+                <menuItem title="Pearl" id="1Xt-HY-uBw">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Pearl" systemMenu="apple" id="uQy-DD-JDr">
+                        <items>
+                            <menuItem title="About Advanced Mac Substitute" id="5kV-Vb-QxS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                            <menuItem title="Services" id="NMo-om-nkz">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                            <menuItem title="Hide Pearl" id="Olw-nP-bQN">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="hide:" target="-1" id="PnN-Uc-m68"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="hideOtherApplications:" target="-1" id="VT4-aY-XCT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show All" id="Kd2-mp-pUS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="unhideAllApplications:" target="-1" id="Dhg-Le-xox"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                            <menuItem title="Quit Pearl" keyEquivalent="q" id="4sb-4s-VLi">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="terminate:" target="-1" id="Te7-pn-YzF"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="File" id="dMs-cI-mzQ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="File" id="bib-Uj-vzu">
+                        <items>
+                            <menuItem title="Close" id="DVo-aG-piG">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="View" id="H8h-7b-M4v">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="View" id="HyV-fh-RgO">
+                        <items>
+                            <menuItem title="Enter Full Screen" id="4J7-dP-txa">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleFullScreen:" target="-1" id="dU3-MA-1Rq"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Window" id="aUF-d1-5bR">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                        <items>
+                            <menuItem title="Minimize" id="OY7-WF-poV">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                            <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="arrangeInFront:" target="-1" id="DRN-fu-gQh"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+            </items>
+        </menu>
+    </objects>
+</document>

--- a/apps/sdl/Pearl/Pearl/Pearl.cc
+++ b/apps/sdl/Pearl/Pearl/Pearl.cc
@@ -1,0 +1,312 @@
+/*
+	Pearl.cc
+	--------
+*/
+
+// Mac OS X
+#ifdef __APPLE__
+#include <CoreFoundation/CFBundle.h>
+#endif
+
+// POSIX
+#include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
+
+// Standard C
+#include <errno.h>
+#include <stdlib.h>
+
+// libsdl2
+#define SDL_MAIN_HANDLED
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_main.h>
+
+// frontend-common
+#include "frend/cursor.hh"
+#include "frend/update_fifo.hh"
+
+// libsndtrack
+#include "event_loop.hh"
+
+// log-of-war
+#include "logofwar/report.hh"
+
+// posix-utils
+#include "posix/bindir.hh"
+
+// rasterlib
+#include "raster/raster.hh"
+
+// v68k-cursor
+#include "cursor/cursor.hh"
+
+// Pearl
+#include "Pearl/audio.hh"
+#include "Pearl/blitter.hh"
+#include "Pearl/cursor.hh"
+#include "Pearl/events.hh"
+#include "Pearl/screen.hh"
+#include "Pearl/tempfile.hh"
+#include "Pearl/window.hh"
+
+
+#define PROGRAM  "Pearl"
+
+
+#ifdef __APPLE__
+
+static
+CFBundleRef get_main_bundle()
+{
+	return CFBundleGetMainBundle();
+}
+
+static
+CFStringRef get_bundle_string( CFBundleRef bundle, CFStringRef key )
+{
+	return (CFStringRef) CFBundleGetValueForInfoDictionaryKey( bundle, key );
+}
+
+static
+CFIndex get_utf8_string_size( CFIndex length )
+{
+	return CFStringGetMaximumSizeForEncoding( length, kCFStringEncodingUTF8 );
+}
+
+static
+CFIndex get_utf8_string_size( CFStringRef str )
+{
+	return get_utf8_string_size( CFStringGetLength( str ) );
+}
+
+static
+void set_app_utf8_string( CFStringRef key, void (*setter)( const char* ) )
+{
+	CFBundleRef main_bundle = get_main_bundle();
+
+	if ( main_bundle == NULL )
+	{
+		return;
+	}
+
+	CFStringRef str = get_bundle_string( main_bundle, key );
+
+	if ( str == NULL )
+	{
+		return;
+	}
+
+	const char* str_utf8 = CFStringGetCStringPtr( str, kCFStringEncodingUTF8 );
+
+	if ( str_utf8 == NULL )
+	{
+		const CFIndex buffer_size = get_utf8_string_size( str );
+
+		char* utf8_buffer = (char*) alloca( buffer_size );
+
+		if ( CFStringGetCString( str, utf8_buffer, buffer_size, kCFStringEncodingUTF8 ) )
+		{
+			str_utf8 = utf8_buffer;
+		}
+	}
+
+	setter( str_utf8 );
+}
+
+static
+void set_app_name( void (*setter)( const char* ) )
+{
+	set_app_utf8_string( CFSTR( "CFBundleName" ), setter );
+}
+
+#else
+
+static
+void set_app_name( void (*setter)( const char* ) )
+{
+	setter( PROGRAM );
+}
+
+#endif
+
+#if ! defined(__MSYS__)  &&  ! defined(__CYGWIN)
+
+static
+void sigchld( int )
+{
+	open( UPDATE_FIFO, O_RDONLY | O_NONBLOCK );
+}
+
+#endif
+
+int run_event_loop( const raster::raster_load& load, const raster::raster_desc& desc )
+{
+	using namespace Pearl;
+
+	const int width  = desc.width;
+	const int height = desc.height;
+	
+	Window window( SDL_GetHint( SDL_HINT_APP_NAME ), width, height );
+	if ( window == NULL )
+	{
+		FATAL = "could not create window";
+		return 1;
+	}
+
+	Blitter blitter( window );
+	blitter.prep( desc.stride, width, height, desc.weight );
+
+	SDL_Point cursor_limit = { width - 1, height - 1 };
+	SDL_Point initial_cursor_location = { 15, 15 };
+	Cursor cursor( cursor_limit, initial_cursor_location, blitter );
+	cursor.set_composite_mode( Cursor::CompositeMode_host_OS );
+
+	bool running = true;
+	SDL_Event event;
+	while ( running )
+	{
+		if ( ! SDL_WaitEvent( &event ) )
+		{
+			continue;
+		}
+
+		if ( event.type == pearl_event_class )
+		{
+			SDL_UserEvent* pearl_event = (SDL_UserEvent*) &event;
+			switch ( pearl_event->code )
+			{
+				case kEventPearlScreenBits:
+					continue;
+
+				case kEventPearlScaleMultiple:
+					window.scale( *(float*) pearl_event->data1 );
+					continue;
+
+				case kEventPearlIntegerScale:
+					blitter.toggle_integer_scaling();
+					continue;
+
+				case kEventPearlFullscreen:
+					window.toggle_fullscreen();
+					cursor.move_to( cursor.get_last_location() );
+					continue;
+
+				case kEventPearlKeyboardGrab:
+					window.toggle_keyboard_grab();
+					continue;
+
+				case kEventPearlMouseGrab:
+					window.toggle_mouse_grab();
+					continue;
+
+				default:
+					break;
+			}
+
+			if ( cursor.get_composite_mode() != Cursor::CompositeMode_software )
+			{
+				using frend::cursor_state;
+				using frend::shared_cursor_state;
+
+				if ( const shared_cursor_state* latest_cursor = cursor_state )
+				{
+					if ( pearl_event->code == kEventPearlCursorBits )
+					{
+						cursor.set( *latest_cursor );
+					}
+
+					cursor.show( latest_cursor->visible );
+				}
+			}
+				
+			window.update( load, desc, blitter );
+			continue;
+		}
+
+		if (           event.type == SDL_WINDOWEVENT &&
+		     ( event.window.event == SDL_WINDOWEVENT_RESIZED ||
+		       event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED ) )
+		{
+			blitter.size( event.window.data1, event.window.data2 );
+			continue;
+		}
+
+		running = handle_sdl_event( event, cursor );
+	}
+
+	return 0;
+}
+
+static
+void set_sdl_app_name( const char* app_name )
+{
+	SDL_SetHint( SDL_HINT_APP_NAME, app_name );
+}
+
+int main( int argc, char** argv )
+{
+	set_app_name( &set_sdl_app_name );
+
+#if ! defined(__MSYS__)  &&  ! defined(__CYGWIN)
+
+	signal( SIGCHLD, &sigchld );
+
+#endif
+
+	// Reserve fds 6 and 7 for graft to connect ams-fs/xv68k to freemountd.
+	dup2( STDERR_FILENO, 6 );
+	dup2( STDERR_FILENO, 7 );
+
+	if ( SDL_Init( SDL_INIT_VIDEO ) != 0 )
+	{
+		FATAL = "could not initialize SDL";
+		return 1;
+	}
+
+	using namespace Pearl;
+
+	const char* works_path = tempfile_location();
+	int nok = mkdir( works_path, 0777 );
+	if ( nok  &&  errno != EEXIST )
+	{
+		FATAL = "could not create temporary directory";
+		return 1;
+	}
+
+	int bindir_fd = bindir( argv[ 0 ] );
+	chdir( works_path );
+
+	// Create the sound fds before launching the coprocess.
+	audio_stream audio;
+
+	try
+	{
+		emulated_screen screen( bindir_fd, works_path );
+		close( bindir_fd );
+
+		audio.start();
+
+		const raster_load& load = screen.load();
+		const raster_desc& desc = screen.desc();
+
+		if ( run_event_loop( load, desc ) != 0 )
+		{
+			WARNING = "could not run event loop";
+		}
+
+		close( events_fd );
+	}
+	catch ( ... )
+	{
+		FATAL = "could not run emulator process";
+	}
+
+	// Stop audio after the coprocess has exited.
+	// Now we can close the sound fd, unblocking libsndtrack's event loop.
+	audio.stop();
+
+	rmdir( works_path );
+
+	return 0;
+}

--- a/apps/sdl/Pearl/Pearl/audio.cc
+++ b/apps/sdl/Pearl/Pearl/audio.cc
@@ -1,0 +1,180 @@
+/*
+	audio.cc
+	--------
+*/
+
+#include "Pearl/audio.hh"
+
+// POSIX
+#include <unistd.h>
+
+// Standard C
+#include <signal.h>
+#include <stdlib.h>
+
+// libsdl2
+#if defined(__MSYS__) || defined(__CYGWIN__)
+// MSYS/Cygwin doesn't know about _beginthreadex / _endthreadex
+#define SDL_beginthread NULL
+#define SDL_endthread NULL
+#endif
+#include <SDL2/SDL.h>
+
+// gear
+#include "gear/inscribe_decimal.hh"
+
+// libsndtrack
+#include "event_loop.hh"
+#include "exceptions.hh"
+#include "output.hh"
+#include "synthesize.hh"
+
+
+namespace Pearl
+{
+
+static const int sample_rate = 7833600 / 352;  // 22254
+
+static SDL_AudioDeviceID device_id = 0;
+static SDL_Thread* thread = NULL;
+
+static const char sound_fd_envvar[] = "AMS_SOUND_FD";
+static int pipe_fds[ 2 ];
+
+static
+void stream_callback( void*, Uint8* stream, int len )
+{
+	if ( len == samples_per_buffer * sizeof (output_sample_t) )
+	{
+		synthesize( stream );
+	}
+}
+
+audio_stream::audio_stream()
+{
+	if ( device_id != 0 )
+	{
+		take_exception( audio_platform_start_error );
+		return;
+	}
+
+	if ( getenv( sound_fd_envvar ) != NULL )
+	{
+		return;
+	}
+
+	if ( SDL_InitSubSystem( SDL_INIT_AUDIO ) != 0 )
+	{
+		take_exception( audio_platform_start_error );
+		return;
+	}
+
+	SDL_AudioSpec spec =
+	{
+		.freq     = sample_rate,
+		.format   = AUDIO_S16SYS,
+		.channels = channel_count,
+		.samples  = 370,
+		.callback = stream_callback,
+		.userdata = NULL,
+	};
+
+	device_id = SDL_OpenAudioDevice( NULL, 0, &spec, NULL, 0 );
+
+	if ( device_id == 0 )
+	{
+		SDL_QuitSubSystem( SDL_INIT_AUDIO );
+		take_exception( audio_platform_start_error );
+		return;
+	}
+
+	if ( pipe( pipe_fds ) )
+	{
+		take_exception( audio_platform_start_error );
+		return;
+	}
+
+	const char* pipe_fd = gear::inscribe_unsigned_decimal( pipe_fds[ 1 ] );
+
+	setenv( sound_fd_envvar, pipe_fd, 0 );
+}
+
+audio_stream::~audio_stream()
+{
+	stop();
+
+	close( pipe_fds[ 0 ] );
+	close( pipe_fds[ 1 ] );
+
+	if ( device_id != 0 )
+	{
+		SDL_CloseAudioDevice( device_id );
+	}
+
+	SDL_QuitSubSystem( SDL_INIT_AUDIO );
+}
+
+static
+bool resume_stream()
+{
+	if ( device_id == 0 )
+	{
+		return false;
+	}
+
+	SDL_PauseAudioDevice( device_id, SDL_FALSE );
+
+	return true;
+}
+
+static
+bool pause_stream()
+{
+	if ( device_id == 0 )
+	{
+		return false;
+	}
+
+	SDL_PauseAudioDevice( device_id, SDL_TRUE );
+
+	return true;
+}
+
+static
+int thread_entry( void* )
+{
+	event_loop( pipe_fds[ 0 ], &resume_stream, &pause_stream );
+
+	return 0;
+}
+
+bool audio_stream::start()
+{
+	if ( device_id == 0  ||  thread != NULL )
+	{
+		return false; 
+	}
+
+	close( pipe_fds[ 1 ] );
+
+	thread = SDL_CreateThread( thread_entry, NULL, NULL );
+
+	return true;
+}
+
+bool audio_stream::stop()
+{
+	if ( thread == NULL )
+	{
+		return false;
+	}
+
+	interrupt( SIGINT );
+
+	SDL_WaitThread( thread, NULL );
+	thread = NULL;
+
+	return true;
+}
+
+}

--- a/apps/sdl/Pearl/Pearl/audio.hh
+++ b/apps/sdl/Pearl/Pearl/audio.hh
@@ -1,0 +1,29 @@
+/*
+	audio.hh
+	--------
+*/
+
+#ifndef PEARL_AUDIO_HH
+#define PEARL_AUDIO_HH
+
+namespace Pearl
+{
+
+struct audio_stream
+{
+	private:
+		// non-copyable
+		audio_stream           ( const audio_stream& );
+		audio_stream& operator=( const audio_stream& );
+
+	public:
+		audio_stream();
+		~audio_stream();
+
+		bool start();
+		bool stop();
+};
+
+}
+
+#endif

--- a/apps/sdl/Pearl/Pearl/blitter.cc
+++ b/apps/sdl/Pearl/Pearl/blitter.cc
@@ -1,0 +1,246 @@
+/*
+	blitter.cc
+	----------
+*/
+
+#include "Pearl/blitter.hh"
+
+// libsdl2
+#include <SDL2/SDL_pixels.h>
+#include <SDL2/SDL_render.h>
+
+
+namespace Pearl
+{
+
+static const SDL_PixelFormatEnum texture_format = SDL_PIXELFORMAT_RGBA8888;
+
+static SDL_Renderer* renderer = NULL;
+static SDL_Surface* src_surface = NULL;
+static SDL_Palette* src_palette = NULL;
+static SDL_Surface* dst_surface = NULL;
+static SDL_Texture* texture = NULL;
+
+static int w, h, row_bytes;
+static SDL_PixelFormatEnum pix_fmt;
+
+static SDL_ScaleMode scale_mode = SDL_ScaleModeNearest;
+
+static bool prefer_integer_scaling = false;
+static bool allow_preferred_modes  = false;
+
+static void reset()
+{
+	if ( src_surface != NULL )
+	{
+		SDL_FreeSurface( src_surface );
+		src_surface = NULL;
+	}
+
+	if ( src_palette != NULL )
+	{
+		SDL_FreePalette( src_palette );
+		src_palette = NULL;
+	}
+
+	if ( dst_surface != NULL )
+	{
+		SDL_FreeSurface( dst_surface );
+		dst_surface = NULL;
+	}
+
+	if ( texture != NULL )
+	{
+		SDL_DestroyTexture( texture );
+		texture = NULL;
+	}
+}
+
+Blitter::Blitter( SDL_Window* window )
+{
+	if ( window != NULL )
+	{
+		renderer = SDL_CreateRenderer( window, -1, 0 );
+	}
+}
+
+Blitter::~Blitter()
+{
+	reset();
+
+	if ( renderer != NULL )
+	{
+		SDL_RenderClear( renderer );
+
+		SDL_DestroyRenderer( renderer );
+		renderer = NULL;
+	}
+}
+
+Blitter::operator SDL_Renderer*() const
+{
+	return renderer;
+}
+
+bool Blitter::prep( int stride, int width, int height, int depth )
+{
+	if ( renderer == NULL )
+	{
+		return false;
+	}
+
+	reset();
+
+	w         = width;
+	h         = height;
+	row_bytes = stride;
+
+	switch ( depth )
+	{
+		case 1:
+			// only monochrome is supported for now
+			pix_fmt = SDL_PIXELFORMAT_INDEX1MSB;
+			break;
+
+		default:
+			return false;
+	}
+
+	src_surface = SDL_CreateRGBSurfaceWithFormatFrom( NULL, w, h, 1, row_bytes, pix_fmt );
+
+	if ( src_surface == NULL )
+	{
+		return false;
+	}
+
+	src_palette = SDL_AllocPalette( 2 );
+
+	SDL_Color colors[ 2 ] =
+	{
+		{ 0xFF, 0xFF, 0xFF, 0xFF },
+		{ 0x00, 0x00, 0x00, 0xFF }
+	};
+
+	if ( SDL_SetPaletteColors( src_palette, colors, 0, 2 ) != 0  ||
+	     SDL_SetSurfacePalette( src_surface, src_palette ) != 0 )
+	{
+		return false;
+	}
+
+	dst_surface = SDL_CreateRGBSurfaceWithFormatFrom( NULL, w, h, 32, w * (32 / 8), texture_format );
+
+	if ( dst_surface == NULL )
+	{
+		return false;
+	}
+
+	texture = SDL_CreateTexture( renderer, texture_format, SDL_TEXTUREACCESS_STREAMING, w, h );
+
+	return SDL_RenderSetLogicalSize( renderer, width, height ) == 0  &&  size( width, height );
+}
+
+bool Blitter::blit( const void* src_addr )
+{
+	if ( renderer == NULL  ||  texture == NULL  ||  src_surface == NULL  ||  dst_surface == NULL )
+	{
+		return false;
+	}
+
+	if ( SDL_LockTexture( texture, NULL, &dst_surface->pixels, &dst_surface->pitch ) == 0 )
+	{
+		src_surface->pixels = (void*) src_addr;
+		src_surface->pitch  = row_bytes;
+
+		SDL_Rect rect =
+		{
+			0, 0,
+			w, h
+		};
+
+		bool did_blit = SDL_LowerBlit( src_surface, &rect, dst_surface, &rect ) == 0;
+
+		SDL_UnlockTexture( texture );
+
+		if ( did_blit )
+		{
+			return refresh();
+		}
+	}
+
+	return false;
+}
+
+bool Blitter::refresh()
+{
+	bool did_refresh = SDL_RenderClear( renderer ) == 0  &&
+	                   SDL_RenderCopy( renderer, texture, NULL, NULL ) == 0;
+
+	if ( ! did_refresh )
+	{
+		return false;
+	}
+
+	SDL_RenderPresent( renderer );
+
+	return did_refresh;
+}
+
+bool Blitter::represent( bool use_integer_scaling )
+{
+	bool did_represent = SDL_SetTextureScaleMode( texture, use_integer_scaling ? SDL_ScaleModeNearest : scale_mode ) == 0  &&
+	                     SDL_RenderSetIntegerScale( renderer, SDL_bool( use_integer_scaling ) ) == 0  &&
+	                     SDL_RenderClear( renderer ) == 0;
+
+	if ( ! did_represent )
+	{
+		return false;
+	}
+
+	SDL_RenderPresent( renderer );
+
+	return refresh();
+}
+
+bool Blitter::size( int width, int height )
+{
+	if ( renderer == NULL  ||  texture == NULL )
+	{
+		return false;
+	}
+
+	// Preserve aspect ratio when using nearest.
+	if ( (  width % w == 0  &&  height >= h *  width / w ) ||
+	     ( height % h == 0  &&   width >= w * height / h ) )
+	{
+		scale_mode = SDL_ScaleModeNearest;
+	}
+	else
+	{
+		scale_mode = SDL_ScaleModeLinear;
+	}
+
+	if ( width <= w  ||  height <= h )
+	{
+		allow_preferred_modes = false;
+		return represent( false );
+	}
+	else
+	{
+		allow_preferred_modes = true;
+		return represent( prefer_integer_scaling );
+	}
+}
+
+bool Blitter::toggle_integer_scaling()
+{
+	if ( renderer == NULL  ||  texture == NULL  ||  ! allow_preferred_modes )
+	{
+		return false;
+	}
+
+	prefer_integer_scaling = ! prefer_integer_scaling;
+
+	return represent( prefer_integer_scaling );
+}
+
+}

--- a/apps/sdl/Pearl/Pearl/blitter.hh
+++ b/apps/sdl/Pearl/Pearl/blitter.hh
@@ -1,0 +1,43 @@
+/*
+	blitter.hh
+	----------
+*/
+
+#ifndef PEARL_BLITTER_HH
+#define PEARL_BLITTER_HH
+
+// libsdl2
+#include <SDL2/SDL_render.h>
+
+
+namespace Pearl
+{
+
+class Blitter
+{
+	private:
+		// non-copyable
+		Blitter           ( const Blitter& );
+		Blitter& operator=( const Blitter& );
+
+		static bool refresh();
+		static bool represent( bool use_integer_scaling );
+
+	public:
+		Blitter( SDL_Window* window );
+		~Blitter();
+
+		operator SDL_Renderer*() const;
+
+		static bool prep( int stride, int width, int height, int depth = 1 );
+
+		static bool blit( const void* src_addr );
+
+		static bool size( int width, int height );
+
+		static bool toggle_integer_scaling();
+};
+
+}
+
+#endif

--- a/apps/sdl/Pearl/Pearl/cursor.cc
+++ b/apps/sdl/Pearl/Pearl/cursor.cc
@@ -1,0 +1,195 @@
+/*
+	cursor.cc
+	---------
+*/
+
+#include "Pearl/cursor.hh"
+
+// libsdl2
+#include <SDL2/SDL_mouse.h>
+#include <SDL2/SDL_rect.h>
+#include <SDL2/SDL_render.h>
+
+// splode
+#include "splode/splode.hh"
+
+// v68k-cursor
+#include "cursor/cursor.hh"
+
+// write-a-splode
+#include "splode/write-a-splode.hh"
+
+// frontend-common
+#include "frend/pinned.hh"
+
+// Pearl
+#include "Pearl/blitter.hh"
+#include "Pearl/events.hh"
+
+
+namespace Pearl
+{
+
+Cursor::Cursor( const SDL_Point& limit,
+                const SDL_Point& initial_location,
+                Blitter& blitter ) : limit( limit ),
+                                     last_location( initial_location ),
+                                     blitter( blitter ),
+                                     preferred_composite_mode( CompositeMode_software ),
+                                     host_cursor( NULL )
+{
+	move_to( initial_location );
+
+	// Don't show double cursors while the window has focus.
+	SDL_ShowCursor( SDL_FALSE );
+}
+
+Cursor::~Cursor()
+{
+	reset();
+}
+
+void Cursor::reset()
+{
+	if ( host_cursor != NULL )
+	{
+		SDL_FreeCursor( host_cursor );
+		host_cursor = NULL;
+	}
+}
+
+template < class T >
+static inline
+bool is_point_equal_to_point( T a, T b )
+{
+	return a.x == b.x  &&  a.y == b.y;
+}
+
+void Cursor::pin( SDL_Point& location )
+{
+	SDL_Point unpinned_location = location;
+
+	location = frend::pinned_location( unpinned_location, limit );
+
+	if ( SDL_GetWindowMouseGrab( SDL_RenderGetWindow( blitter ) )  &&
+	     ! is_point_equal_to_point( location, unpinned_location ) )
+	{
+		move_to( location );
+	}
+}
+
+void Cursor::move_to( SDL_Point location )
+{
+	SDL_Renderer* renderer = (SDL_Renderer*) blitter;
+
+	if ( renderer != NULL )
+	{
+		SDL_RenderLogicalToWindow( renderer,
+		                           (float) location.x,
+		                           (float) location.y,
+		                           &location.x,
+		                           &location.y );
+	}
+
+	SDL_WarpMouseInWindow( SDL_RenderGetWindow( blitter ), location.x, location.y );
+}
+
+SDL_Point Cursor::get_last_location() const
+{
+	return last_location;
+}
+
+void Cursor::send_mouse_moved_event( const SDL_Point& location )
+{
+	SDL_Point pinned_location = location;
+
+	pin( pinned_location );
+
+	if ( ! is_point_equal_to_point( pinned_location, last_location ) )
+	{
+		using splode::send_mouse_moved_event;
+
+		send_mouse_moved_event( events_fd, pinned_location.x, pinned_location.y );
+
+		last_location = pinned_location;
+	}
+}
+
+void Cursor::send_mouse_button_event( uint8_t modes, bool button_down )
+{
+	using namespace splode::pointer;
+
+	uint8_t attrs = 0;
+	if ( button_down )
+	{
+		attrs |= down;
+	}
+	else
+	{
+		attrs |= up;
+	}
+
+	splode::send_mouse_event( events_fd, modes, attrs );
+}
+
+bool Cursor::show( bool visible )
+{
+	return SDL_ShowCursor( visible ) >= 0;
+}
+
+bool Cursor::set( const frend::shared_cursor_state& cursor )
+{
+	if ( preferred_composite_mode != CompositeMode_host_OS )
+	{
+		// TODO
+		return false;
+	}
+
+	reset();
+
+	host_cursor = SDL_CreateCursor( (uint8_t*) cursor.face,
+	                                (uint8_t*) cursor.mask,
+	                                16, 16,
+	                                cursor.hotspot[ 1 ],
+	                                cursor.hotspot[ 0 ] );
+
+	if ( host_cursor == NULL )
+	{            
+		return false;
+	}
+
+	SDL_SetCursor( host_cursor );	
+
+	return true;
+}
+
+void Cursor::set_composite_mode( CompositeMode mode )
+{
+	if ( preferred_composite_mode == mode )
+	{
+		return;
+	}
+
+	switch ( preferred_composite_mode )
+	{
+		case CompositeMode_texture:
+			// TODO
+			break;
+
+		case CompositeMode_host_OS:
+			reset();
+			break;
+
+		default:
+			break;
+	}
+
+	preferred_composite_mode = mode;
+}
+
+Cursor::CompositeMode Cursor::get_composite_mode() const
+{
+	return preferred_composite_mode;
+}
+
+}

--- a/apps/sdl/Pearl/Pearl/cursor.hh
+++ b/apps/sdl/Pearl/Pearl/cursor.hh
@@ -1,0 +1,71 @@
+/*
+	cursor.hh
+	---------
+*/
+
+#ifndef PEARL_CURSOR_HH
+#define PEARL_CURSOR_HH
+
+// frontend-common
+#include "frend/cursor.hh"
+
+// libsdl2
+#include <SDL2/SDL_rect.h>
+
+
+struct SDL_Cursor;
+
+namespace Pearl
+{
+
+class Blitter;
+
+class Cursor
+{
+	public:
+		enum CompositeMode
+		{
+			CompositeMode_software = 0,
+			CompositeMode_texture  = 1,
+			CompositeMode_host_OS  = 2,
+		};
+
+	private:
+		SDL_Point limit;
+		SDL_Point last_location;
+
+		Blitter& blitter;
+
+		CompositeMode preferred_composite_mode;
+
+		SDL_Cursor* host_cursor;
+
+		void reset();
+
+		void pin( SDL_Point& location );
+
+		// non-copyable
+		Cursor           ( const Cursor& );
+		Cursor& operator=( const Cursor& );
+
+	public:
+		Cursor( const SDL_Point& limit, const SDL_Point& initial_location, Blitter& blitter );
+		~Cursor();
+
+		void move_to( SDL_Point location );
+		SDL_Point get_last_location() const;
+
+		void send_mouse_moved_event( const SDL_Point& location );
+		void send_mouse_button_event( uint8_t modes, bool button_down );
+
+		bool show( bool visible );
+
+		bool set( const frend::shared_cursor_state& cursor );
+
+		void set_composite_mode( CompositeMode composite_mode );
+		CompositeMode get_composite_mode() const;
+};
+
+}
+
+#endif

--- a/apps/sdl/Pearl/Pearl/events.cc
+++ b/apps/sdl/Pearl/Pearl/events.cc
@@ -1,0 +1,236 @@
+/*
+	events.cc
+	---------
+*/
+
+#include "Pearl/events.hh"
+
+// libsdl2
+#include <SDL2/SDL_events.h>
+#include <SDL2/SDL_rect.h>
+
+// splode
+#include "splode/splode.hh"
+
+// write-a-splode
+#include "splode/write-a-splode.hh"
+
+// Pearl
+#include "Pearl/cursor.hh"
+#include "Pearl/keycodes.hh"
+
+
+namespace Pearl
+{
+
+int events_fd = -1;
+
+uint32_t pearl_event_class;
+
+static float scale;
+
+static bool Q_hit = false;
+static bool X_hit = false;
+
+static inline
+uint8_t get_modes( SDL_Keymod modifiers )
+{
+	using namespace splode::modes;
+	using namespace splode::key;
+
+	uint8_t modes = 0;
+
+	if ( modifiers & KMOD_SHIFT )
+	{
+		modes |= Shift;
+	}
+
+	if ( modifiers & KMOD_CTRL )
+	{
+		modes |= Control;
+	}
+
+	if ( modifiers & KMOD_ALT )
+	{
+		modes |= Option;
+	}
+
+	if ( modifiers & KMOD_GUI )
+	{
+		modes |= Command;
+	}
+
+	return modes;
+}
+
+static inline
+bool is_keypad( SDL_Scancode scancode )
+{
+	return scancode >= SDL_SCANCODE_NUMLOCKCLEAR  &&
+	       scancode <= SDL_SCANCODE_KP_PERIOD;
+}
+
+static
+void send_key_event( const SDL_KeyboardEvent& event, char c )
+{
+	using namespace splode::modes;
+	using namespace splode::key;
+
+	uint8_t modes = get_modes( SDL_GetModState() );
+	uint8_t attrs = 0;
+
+	if ( SDL_GetModState() & KMOD_CAPS )
+	{
+		attrs |= Alpha;
+	}
+
+	if ( event.repeat )
+	{
+		attrs |= held;
+	}
+	else
+	{
+		if ( event.state == SDL_PRESSED )
+		{
+			attrs |= down;
+		}
+		else
+		{
+			attrs |= up;
+		}
+	}
+
+	if ( is_keypad( event.keysym.scancode ) )
+	{
+		attrs |= Keypad;
+	}
+
+	splode::send_key_event( events_fd, c, modes, attrs );
+}
+
+static
+void clear_chords()
+{
+	Q_hit = false;
+	X_hit = false;
+}
+
+static
+bool handle_command( const SDL_KeyboardEvent& event )
+{
+	const SDL_EventType eventClass    = (SDL_EventType) pearl_event_class;
+	const Sint32        scaleMultiple = kEventPearlScaleMultiple;
+	const Sint32        integerScale  = kEventPearlIntegerScale;
+	const Sint32        fullScreen    = kEventPearlFullscreen;
+	const Sint32        keyboardGrab  = kEventPearlKeyboardGrab;
+	const Sint32        mouseGrab     = kEventPearlMouseGrab;
+
+	switch ( event.keysym.scancode )
+	{
+		case SDL_SCANCODE_Q:  Q_hit = true;  break;
+		case SDL_SCANCODE_X:  X_hit = true;  break;
+
+		case SDL_SCANCODE_EQUALS:
+		case SDL_SCANCODE_MINUS:
+		{
+			SDL_UserEvent scale_multiple = { eventClass };
+			scale_multiple.code = scaleMultiple;
+			scale = event.keysym.scancode == SDL_SCANCODE_MINUS ? -0.5 : 0.5;
+			scale_multiple.data1 = &scale;
+			return SDL_PushEvent( (SDL_Event*) &scale_multiple );
+		}
+
+		case SDL_SCANCODE_I:
+		{
+			SDL_UserEvent integer_scale = { eventClass };
+			integer_scale.code = integerScale;
+			return SDL_PushEvent( (SDL_Event*) &integer_scale );
+		}
+
+		case SDL_SCANCODE_RETURN:
+		{
+			SDL_UserEvent full_screen = { eventClass };
+			full_screen.code = fullScreen;
+			return SDL_PushEvent( (SDL_Event*) &full_screen );
+		}
+
+		case SDL_SCANCODE_K:
+		{
+			SDL_UserEvent keyboard_grab = { eventClass };
+			keyboard_grab.code = keyboardGrab;
+			return SDL_PushEvent( (SDL_Event*) &keyboard_grab );
+		}
+
+		case SDL_SCANCODE_M:
+		{
+			SDL_UserEvent mouse_grab = { eventClass };
+			mouse_grab.code = mouseGrab;
+			return SDL_PushEvent( (SDL_Event*) &mouse_grab );
+		}
+
+		default:
+			return false;
+	}
+
+	if ( Q_hit  &&  X_hit )
+	{
+		SDL_QuitEvent quit_event = { SDL_QUIT };
+		return SDL_PushEvent( (SDL_Event*) &quit_event );
+	}
+
+	return true;
+}
+
+bool handle_sdl_event( SDL_Event& event, Cursor& cursor )
+{
+	switch ( event.type )
+	{
+		case SDL_KEYDOWN:
+			if ( (SDL_GetModState() & KMOD_ALT) == KMOD_ALT )
+			{
+				handle_command( event.key );
+				break;
+			}
+			else
+			{
+				clear_chords();
+			}
+
+			// Fall through to...
+
+		case SDL_KEYUP:
+			send_key_event( event.key, lookup_from_sdl_scancode[ event.key.keysym.scancode ] );
+			break;
+
+		case SDL_MOUSEMOTION:
+		{
+			SDL_Point location = { (int) event.motion.x, (int) event.motion.y };
+			cursor.send_mouse_moved_event( location );
+			break;
+		}
+
+		case SDL_MOUSEBUTTONDOWN:
+		case SDL_MOUSEBUTTONUP:
+		{
+			SDL_Point location = { (int) event.button.x, (int) event.button.y };
+			cursor.send_mouse_moved_event( location );
+
+			if ( event.button.button == 1 )
+			{
+				cursor.send_mouse_button_event( get_modes( SDL_GetModState() ),
+				                                event.button.state == SDL_PRESSED );
+			}
+			break;
+		}
+
+		case SDL_QUIT:
+			return false;
+
+		default:
+			break;
+	}
+
+	return true;
+}
+
+}

--- a/apps/sdl/Pearl/Pearl/events.hh
+++ b/apps/sdl/Pearl/Pearl/events.hh
@@ -1,0 +1,41 @@
+/*
+	events.hh
+	---------
+*/
+
+#ifndef PEARL_EVENTS_HH
+#define PEARL_EVENTS_HH
+
+// Standard C
+#include <stdint.h>
+
+
+union SDL_Event;
+
+namespace Pearl
+{
+
+class Cursor;
+
+extern int events_fd;
+
+extern uint32_t pearl_event_class;
+
+enum
+{
+	kEventPearlUpdate = 1,
+	kEventPearlScreenBits = 2,
+	kEventPearlCursorBits = 3,
+
+	kEventPearlScaleMultiple = 4,
+	kEventPearlIntegerScale = 5,
+	kEventPearlFullscreen = 6,
+	kEventPearlKeyboardGrab = 7,
+	kEventPearlMouseGrab = 8,
+};
+
+bool handle_sdl_event( SDL_Event& event, Cursor& cursor );
+
+}
+
+#endif

--- a/apps/sdl/Pearl/Pearl/keycodes.cc
+++ b/apps/sdl/Pearl/Pearl/keycodes.cc
@@ -1,0 +1,299 @@
+/*
+	keycodes.cc
+	-----------
+*/
+
+#include "Pearl/keycodes.hh"
+
+// libsdl2
+#include <SDL2/SDL_scancode.h>
+
+
+#define ____ 0x00
+#define F(n) ____
+
+
+namespace Pearl
+{
+
+const unsigned char lookup_from_sdl_scancode[ SDL_NUM_SCANCODES ] =
+{
+	____,  // SDL_SCANCODE_UNKNOWN
+
+	____,  // unused
+	____,  // unused
+	____,  // unused
+
+	'a',
+	'b',
+	'c',
+	'd',
+	'e',
+	'f',
+	'g',
+	'h',
+	'i',
+	'j',
+	'k',
+	'l',
+	'm',
+	'n',
+	'o',
+	'p',
+	'q',
+	'r',
+	's',
+	't',
+	'u',
+	'v',
+	'w',
+	'x',
+	'y',
+	'z',
+
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9',
+	'0',
+	
+	0x0D,  // Return
+	0x1B,  // Escape
+	0x08,  // Backspace / Delete
+	0x09,  // Tab
+	' ',
+
+	'-',
+	'=',
+	'[',
+	']',
+	'\\',
+	'\\',
+	';',
+	'\'',
+	'`',
+	',',
+	'.',
+	'/',
+	
+	____,  // Caps Lock
+
+	F(1),
+	F(2),
+	F(3),
+	F(4),
+	F(5),
+	F(6),
+	F(7),
+	F(8),
+	F(9),
+	F(10),
+	F(11),
+	F(12),
+	____,  // Print Screen
+	____,  // Scroll Lock
+	____,  // Pause
+
+	0x05,  // Help
+	0x01,  // Home
+	0x0B,  // Page Up
+	0x7F,  // FwdDel
+	0x04,  // End
+	0x0C,  // Page Down
+	0x1D,  // Right
+	0x1C,  // Left
+	0x1F,  // Down
+	0x1E,  // Up
+
+	// Keypad
+
+	0x1B,  // Clear
+	'/',
+	'*',
+	'-',
+	'+',
+	0x03,  // Enter
+	'1',
+	'2',
+	'3',
+	'4',
+	'5',
+	'6',
+	'7',
+	'8',
+	'9',
+	'0',
+	'.',
+
+	'`',
+	____,  // Application
+	____,  // Power
+	'=',
+	F(13),
+	F(14),
+	F(15),
+	F(16),
+	F(17),
+	F(18),
+	F(19),
+	F(20),
+	F(21),
+	F(22),
+	F(23),
+	F(24),
+	____,  // Execute
+	____,  // Help
+	____,  // Menu
+	____,  // Select
+	____,  // Stop
+	____,  // Again
+	____,  // Undo
+	____,  // Cut
+	____,  // Copy
+	____,  // Paste
+	____,  // Find
+	____,  // Mute
+	____,  // Volume Up
+	____,  // Volume Down
+	____,  // Locking Caps Lock
+	____,  // Locking Num Lock
+	____,  // Locking Scroll Lock
+	',',
+	'=',
+
+	____,
+	____,
+	____,  // Yen
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,  // Hangul/English
+	____,  // Hanja
+	____,  // Katakana
+	____,  // Hiragana
+	____,  // Zenkaku/Hankaku
+	____,
+	____,
+	____,
+	____,
+
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,  // A
+	____,  // B
+	____,  // C
+	____,  // D
+	____,  // E
+	____,  // F
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+	____,
+
+	____,  // Left Control
+	____,  // Left Shift
+	____,  // Left Option
+	____,  // Left Command
+	____,  // Right Control
+	____,  // Right Shift
+	____,  // Right Option
+	____,  // Right Command
+
+	____,  // Mode
+
+	____,  // Next
+	____,  // Previous
+	____,  // Stop
+	____,  // Play
+	____,  // Mute
+	____,  // Select
+	____,  // WWW
+	____,  // Mail
+	____,  // Calculator
+	____,  // Computer
+	____,  // Search
+	____,  // Home
+	____,  // Back
+	____,  // Forward
+	____,  // Stop
+	____,  // Refresh
+	____,  // Bookmarks
+
+	____,  // Brightness Down
+	____,  // Brightness Up
+	____,  // Display Switch
+
+	____,  // Keyboard Light Toggle
+	____,  // Keyboard Brightness Down
+	____,  // Keyboard Brightness Up
+	____,  // Eject
+	____,  // Sleep
+
+	____,
+	____,
+
+	____,  // Rewind
+	____,  // Fast Forward
+
+	____,
+	____,
+	____,
+	____,
+};
+
+}

--- a/apps/sdl/Pearl/Pearl/keycodes.hh
+++ b/apps/sdl/Pearl/Pearl/keycodes.hh
@@ -1,0 +1,17 @@
+/*
+	keycodes.hh
+	-----------
+*/
+
+#ifndef PEARL_KEYCODES_HH
+#define PEARL_KEYCODES_HH
+
+
+namespace Pearl
+{
+
+extern const unsigned char lookup_from_sdl_scancode[];
+
+}
+
+#endif

--- a/apps/sdl/Pearl/Pearl/screen.cc
+++ b/apps/sdl/Pearl/Pearl/screen.cc
@@ -1,0 +1,143 @@
+/*
+	screen.cc
+	---------
+*/
+
+#include "Pearl/screen.hh"
+
+// POSIX
+#include <fcntl.h>
+#include <unistd.h>
+
+// libsdl2
+#if defined(__MSYS__) || defined(__CYGWIN__)
+// MSYS/Cygwin doesn't know about _beginthreadex / _endthreadex
+#define SDL_beginthread NULL
+#define SDL_endthread NULL
+#endif
+#include <SDL2/SDL_events.h>
+#include <SDL2/SDL_thread.h>
+
+// frontend-common
+#include "frend/coprocess.hh"
+#include "frend/cursor.hh"
+#include "frend/make_cursor.hh"
+#include "frend/make_raster.hh"
+#include "frend/raster_updating.hh"
+#include "frend/update_fifo.hh"
+
+// rasterlib
+#include "raster/raster.hh"
+#include "raster/relay_detail.hh"
+#include "raster/sync.hh"
+
+// v68k-cursor
+#include "cursor/cursor.hh"
+
+// Pearl
+#include "Pearl/events.hh"
+
+
+namespace Pearl
+{
+
+using raster::raster_desc;
+using raster::raster_load;
+
+static bool monitoring;
+
+static SDL_Thread* raster_thread;
+
+static
+void raster_event_loop( const raster::sync_relay* sync )
+{
+	const SDL_EventType eventClass = (SDL_EventType) pearl_event_class;
+	const Sint32        repaintDue = kEventPearlUpdate;
+	const Sint32        screenBits = kEventPearlScreenBits;
+	const Sint32        cursorBits = kEventPearlCursorBits;
+
+	SDL_UserEvent repaint_due = { eventClass };
+	SDL_UserEvent screen_bits = { eventClass };
+	SDL_UserEvent cursor_bits = { eventClass };
+	repaint_due.code = repaintDue;
+	screen_bits.code = screenBits;
+	cursor_bits.code = cursorBits;
+
+	uint32_t raster_seed = 0;
+	uint16_t cursor_seed = 0;
+
+	while ( monitoring  &&  sync->status == raster::Sync_ready )
+	{
+		using frend::cursor_state;
+
+	#if ! defined(__MSYS__)  &&  ! defined(__CYGWIN__)
+
+		close( open( UPDATE_FIFO, O_WRONLY ) );
+
+	#else
+
+		usleep( 8333 );
+
+	#endif
+
+		if ( cursor_state  &&  cursor_state->seed != cursor_seed )
+		{
+			cursor_seed = cursor_state->seed;
+
+			SDL_PushEvent( (SDL_Event*) &cursor_bits );
+		}
+
+		if ( raster_seed != sync->seed )
+		{
+			raster_seed = sync->seed;
+
+			SDL_PushEvent( (SDL_Event*) &screen_bits );
+		}
+
+		SDL_PushEvent( (SDL_Event*) &repaint_due );
+	}
+}
+
+static
+int raster_thread_entry( void* arg )
+{
+	const raster::sync_relay* sync = (const raster::sync_relay*) arg;
+
+	raster_event_loop( sync );
+
+	SDL_QuitEvent quitEvent = { SDL_QUIT };
+	return SDL_PushEvent( (SDL_Event*) &quitEvent ) ? 0 : 1;
+}
+
+raster_monitor::raster_monitor( const raster::raster_load& load )
+{
+	pearl_event_class = SDL_RegisterEvents( 1 );
+
+	const raster::sync_relay* sync = find_sync( &load.meta->note );
+
+	monitoring = true;
+
+	raster_thread = SDL_CreateThread( &raster_thread_entry, NULL, (void*) sync );
+}
+
+raster_monitor::~raster_monitor()
+{
+	monitoring = false;
+
+	SDL_WaitThread( raster_thread, NULL );
+}
+
+static const char raster_path[] = "screen.skif";
+static const char cursor_path[] = "cursor.skif";
+
+emulated_screen::emulated_screen( int bindir_fd, const char* works_path )
+:
+	live_cursor       ( cursor_path ),
+	live_raster       ( raster_path ),
+	monitored_raster  ( live_raster.get() ),
+	launched_coprocess( bindir_fd, works_path )
+{
+	events_fd = launched_coprocess.socket();
+}
+
+}

--- a/apps/sdl/Pearl/Pearl/screen.hh
+++ b/apps/sdl/Pearl/Pearl/screen.hh
@@ -1,0 +1,61 @@
+/*
+	screen.hh
+	---------
+*/
+
+#ifndef PEARL_SCREEN_HH
+#define PEARL_SCREEN_HH
+
+// POSIX
+#include <sys/stat.h>
+
+// frontend-common
+#include "frend/coprocess.hh"
+#include "frend/make_cursor.hh"
+#include "frend/make_raster.hh"
+#include "frend/raster_updating.hh"
+
+
+namespace Pearl
+{
+
+using raster::raster_desc;
+using raster::raster_load;
+
+class raster_monitor
+{
+	private:
+		// non-copyable
+		raster_monitor           ( const raster_monitor& );
+		raster_monitor& operator=( const raster_monitor& );
+
+	public:
+		explicit raster_monitor( const raster::raster_load& load );
+
+		~raster_monitor();
+};
+
+class emulated_screen
+{
+	typedef frend::coprocess_launch coprocess_launch;
+	typedef frend::cursor_lifetime  cursor_lifetime;
+	typedef frend::raster_lifetime  raster_lifetime;
+	typedef frend::raster_updating  raster_updating;
+
+	private:
+		cursor_lifetime   live_cursor;
+		raster_lifetime   live_raster;
+		raster_updating   update_fifo;
+		raster_monitor    monitored_raster;
+		coprocess_launch  launched_coprocess;
+
+	public:
+		emulated_screen( int bindir_fd, const char* works_path );
+
+		const raster_load& load() const  { return live_raster.get(); }
+		const raster_desc& desc() const  { return live_raster.desc(); }
+};
+
+}
+
+#endif

--- a/apps/sdl/Pearl/Pearl/tempfile.cc
+++ b/apps/sdl/Pearl/Pearl/tempfile.cc
@@ -1,0 +1,37 @@
+/*
+	tempfile.cc
+	-----------
+*/
+
+#include "Pearl/tempfile.hh"
+
+// POSIX
+#include <unistd.h>
+
+// gear
+#include "gear/inscribe_decimal.hh"
+
+// plus
+#include "plus/var_string.hh"
+
+// frontend-common
+#include "frend/tempdir.hh"
+
+
+namespace Pearl
+{
+
+const char* tempfile_location()
+{
+	static plus::var_string path;
+	
+	path = frend::tempdir_path();
+	
+	path += "/pearl-";
+	path += gear::inscribe_unsigned_decimal( getpid() );
+	path += ".works";
+	
+	return path.c_str();
+}
+
+}

--- a/apps/sdl/Pearl/Pearl/tempfile.hh
+++ b/apps/sdl/Pearl/Pearl/tempfile.hh
@@ -1,0 +1,16 @@
+/*
+	tempfile.hh
+	-----------
+*/
+
+#ifndef PEARL_TEMPFILE_HH
+#define PEARL_TEMPFILE_HH
+
+namespace Pearl
+{
+
+const char* tempfile_location();
+
+}
+
+#endif

--- a/apps/sdl/Pearl/Pearl/window.cc
+++ b/apps/sdl/Pearl/Pearl/window.cc
@@ -1,0 +1,145 @@
+/*
+	window.cc
+	---------
+*/
+
+#include "Pearl/window.hh"
+
+// Standard C++
+#include <algorithm>
+
+// Standard C
+#include <math.h>
+
+// libsdl2
+#include <SDL2/SDL_video.h>
+
+// Pearl
+#include "Pearl/blitter.hh"
+
+
+namespace Pearl
+{
+
+Window::Window( const char* title,
+                uint32_t screen_width,
+                uint32_t screen_height,
+                uint32_t window_width,
+                uint32_t window_height ) : screen_w( screen_width ),
+                                           screen_h( screen_height )
+{
+	window = SDL_CreateWindow( title,
+	                           SDL_WINDOWPOS_UNDEFINED,
+	                           SDL_WINDOWPOS_UNDEFINED,
+	                           window_width  ? window_width  : screen_width,
+	                           window_height ? window_height : screen_height,
+	                           SDL_WINDOW_RESIZABLE );
+
+	if ( window != NULL )
+	{
+		SDL_SetWindowKeyboardGrab( window, SDL_TRUE );
+		SDL_SetWindowMouseGrab( window, SDL_TRUE );
+	}
+}
+
+Window::~Window()
+{
+	if ( window != NULL )
+	{
+		SDL_DestroyWindow( window );
+	}
+}
+
+Window::operator SDL_Window*() const
+{
+	return window;
+}
+
+void Window::update( const raster_load& load, const raster_desc& desc, Blitter& blitter )
+{
+	const uint32_t offset = desc.height * desc.stride * desc.frame;
+
+	blitter.blit( (char*) load.addr + offset );
+}
+
+bool Window::scale( float scale_multiple )
+{
+	if ( window == NULL )
+	{
+		return false;
+	}
+
+	int w;
+	int h;
+
+	SDL_GetWindowSize( window, &w, &h );
+
+	float this_scale = std::min( (float) w / screen_w, (float) h / screen_h ) / fabs( scale_multiple );
+	float base_scale = scale_multiple < 0.0 ? ceilf( this_scale ) : floorf( this_scale );
+	float next_scale = ( base_scale + copysignf( 1.0, scale_multiple ) ) / this_scale;
+
+	SDL_SetWindowSize( window,
+	                   (int) w * next_scale,
+	                   (int) h * next_scale );
+
+	return true;
+}
+
+bool Window::toggle_fullscreen()
+{
+	if ( window == NULL )
+	{
+		return false;
+	}
+
+	bool was_fullscreen = SDL_GetWindowFlags( window ) & SDL_WINDOW_FULLSCREEN;
+
+	if ( was_fullscreen )
+	{
+		bool windowed = SDL_SetWindowFullscreen( window, 0 ) == 0;
+
+		if ( windowed )
+		{
+			SDL_SetWindowSize( window, windowed_w, windowed_h );
+			SDL_SetWindowPosition( window, windowed_x, windowed_y );
+		}
+
+		return windowed;
+	}
+	else
+	{
+		SDL_GetWindowSize( window, &windowed_w, &windowed_h );
+		SDL_GetWindowPosition( window, &windowed_x, &windowed_y );
+		return SDL_SetWindowFullscreen( window, SDL_WINDOW_FULLSCREEN_DESKTOP ) == 0;
+	}
+
+	return false;
+}
+
+bool Window::toggle_keyboard_grab()
+{
+	if ( window == NULL )
+	{
+		return false;
+	}
+
+	SDL_bool was_grabbed = SDL_GetWindowKeyboardGrab( window );
+	SDL_SetWindowKeyboardGrab( window, SDL_bool( ! was_grabbed ) );
+
+	return true;
+}
+
+bool Window::toggle_mouse_grab()
+{
+	if ( window == NULL )
+	{
+		return false;
+	}
+
+	SDL_bool was_grabbed = SDL_GetWindowMouseGrab( window );
+	SDL_SetWindowMouseGrab( window, SDL_bool( ! was_grabbed ) );
+
+	return true;
+}
+
+}

--- a/apps/sdl/Pearl/Pearl/window.hh
+++ b/apps/sdl/Pearl/Pearl/window.hh
@@ -1,0 +1,58 @@
+/*
+	window.hh
+	---------
+*/
+
+#ifndef PEARL_WINDOW_HH
+#define PEARL_WINDOW_HH
+
+// frontend-common
+#include "frend/make_raster.hh"
+
+
+struct SDL_Window;
+
+namespace Pearl
+{
+
+class Blitter;
+class Cursor;
+
+using raster::raster_load;
+using raster::raster_desc;
+
+class Window
+{
+	private:
+		SDL_Window* window;
+
+		uint32_t screen_w;
+		uint32_t screen_h;
+
+		int windowed_x;
+		int windowed_y;
+		int windowed_w;
+		int windowed_h;
+
+		// non-copyable
+		Window           ( const Window& );
+		Window& operator=( const Window& );
+
+	public:
+		Window( const char* title, uint32_t screen_width, uint32_t screen_height, uint32_t window_width = 0, uint32_t window_height = 0 );
+		~Window();
+
+		operator SDL_Window*() const;
+
+		void update( const raster_load& load, const raster_desc& desc, Blitter& blitter );
+
+		bool scale( float scale_factor );
+
+		bool toggle_fullscreen();
+		bool toggle_keyboard_grab();
+		bool toggle_mouse_grab();
+};
+
+}
+
+#endif

--- a/apps/sdl/Pearl/README.md
+++ b/apps/sdl/Pearl/README.md
@@ -1,0 +1,26 @@
+Pearl
+=====
+
+This program acts as a front end to [Advanced Mac Substitute][AMS], built upon the [SDL2][SDL] library, which supports targeting a [number of platforms][Installation].  Intended as a drop-in replacement for [Amber][]/[Amethyst][]/[Amphitheatre][], it integrates [libsndtrack][] directly, providing support for the [sndpipe][] protocol in addition to handling 1-bit SKIF files (optionally including cursors) and events as expected.  Much of the shared logic common to all front ends has been moved to the [frontend-common][] library.
+
+[AMS]:  <https://www.v68k.org/advanced-mac-substitute/>
+
+[SDL]:  <https://www.libsdl.org/>
+[Installation]:  <https://wiki.libsdl.org/SDL2/Installation>
+
+[Amber]:  <../../mac/Amber/>
+[Amethyst]:  <../../mac/Amethyst/>
+[Amphitheatre]:  <../../mac/Amphitheatre/>
+
+[libsndtrack]:  <../../../sound/libsndtrack/>
+[sndpipe]:  <../../../sound/sndpipe-api/>
+
+[frontend-common]:  <../../../graphics/frontend-common/>
+
+Special thanks to Josh Juran for developing [amicus][], on which Pearl is originally based.
+
+[amicus]:  <../../../mac/libs/amicus/>
+
+Pearl is copyright 2024-2025 Keith Kaisershot.  All rights reserved (unless explicitly stated otherwise).  Pearl is free software; you may use it under the terms of the [GNU AGPL version 3][AGPL] (or later).
+
+[AGPL]:  <../../../LICENSE/AGPL-3.0.txt>

--- a/libs/libsdl2/A-line.conf
+++ b/libs/libsdl2/A-line.conf
@@ -1,0 +1,3 @@
+imports -lSDL2
+
+macosx-version-min 10.7


### PR DESCRIPTION
Pearl is to SDL what the existing amicus-based front ends are to the macOS APIs-- interacting with Advanced Mac Substitute on Windows/MSYS hosts no longer requires the use of a VNC client. Pearl is built upon the SDL2 library, which supports targeting a number of platforms (https://wiki.libsdl.org/SDL2/Installation), however only Mac OS X >= 10.7, Arch Linux, and Windows 10 have been so far tested by the author. Intended as a drop-in replacement for Amber/Amethyst/Amphitheatre, it integrates libsndtrack directly, providing support for the sndpipe protocol in addition to handling 1-bit SKIF files (optionally including cursors) and events as expected. A new libs/libsdl2 pseudo-project and a minor non-breaking change to launch-ams-app.vx are included in this patchset to support this new front end.

Pearl's window can be arbitrarily resized, and the enclosed emulated screen will maintain its aspect ratio using letterboxing/pillarboxing. Various runtime toggles can be switched using `Left Alt` + `Right Alt` + the following key shortcuts:
| Combination | Effect |
| ----------- | ------ |
| Q + X | quit Pearl |
| plus | scale the emulated screen up to its next closest 50% multiple, proportionally scaling the border |
| minus | scale the emulated screen down to its next closest 50% multiple, proportionally scaling the border |
| I | toggle integer scaling of the emulated screen (off by default) |
| enter | toggle windowed full screen mode |
| K | toggle keyboard grab (on by default) |
| M | toggle mouse grab (on by default) |

Note that compositing the hardware cursor as a texture is not yet supported, and is instead simply implemented as a no-op for now. Toggling the hardware cursor composite mode is anyway not implemented at all currently, so this no-op behavior should not be evident to users.